### PR TITLE
[enhancement] Add: Dockerfile에서 jar 파일도 생성(gradle build)하도록 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
+FROM gradle AS build
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+# jar 파일 생성
+RUN gradle build --no-daemon --exclude-task test
+
 FROM openjdk:11-jre-slim as builder
 WORKDIR app
-ARG JAR_FILE=build/libs/*-SNAPSHOT.jar
-COPY ${JAR_FILE} application.jar
+ARG JAR_FILE=/home/gradle/src/build/libs/*-SNAPSHOT.jar
+# Container 내부에 생성된 jar 파일 복사
+COPY --from=build ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
+# Create the containerized application
 FROM openjdk:11-jre-slim
 WORKDIR app
 COPY --from=builder app/dependencies/ ./
@@ -11,5 +19,7 @@ COPY --from=builder app/spring-boot-loader/ ./
 COPY --from=builder app/snapshot-dependencies/ ./
 COPY --from=builder app/application/ ./
 COPY wait-for-it.sh /app/src/wait-for-it.sh
+
+# 파일 실행을 위한 권한 변경
 RUN ["chmod", "+x", "/app/src/wait-for-it.sh"]
 ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -12,7 +12,7 @@ services:
       - "8080:8080"
     depends_on:
       - cardoc_db
-    entrypoint: /app/src/wait-for-it.sh cardoc_db:3306 -- java org.springframework.boot.loader.JarLauncher
+    entrypoint: /app/src/wait-for-it.sh cardoc_db:3306 -t 120 -- java org.springframework.boot.loader.JarLauncher
 
   cardoc_db:
     container_name: cardoc_database

--- a/docker-compose-real.yml
+++ b/docker-compose-real.yml
@@ -12,7 +12,7 @@ services:
       - "8080:8080"
     depends_on:
       - cardoc_db
-    entrypoint: /app/src/wait-for-it.sh cardoc_db:3306 -- java org.springframework.boot.loader.JarLauncher
+    entrypoint: /app/src/wait-for-it.sh cardoc_db:3306 -t 120 -- java org.springframework.boot.loader.JarLauncher
 
   cardoc_db:
     container_name: cardoc_database


### PR DESCRIPTION
## 추가 및 변경 사항
- 기존: docker-compose up 으로 실행하기 전에 terminal에서 gradle build를 수행해야 함
- 개선: Dockerfile에 gradle build 내용 추가하여 docker-compose up 만으로 어플리케이션 실행 가능하도록 함

### issue
#17 